### PR TITLE
[AA-1359] - Research fix to scenario where attempting to uninstall/upgrade leads to an exception

### DIFF
--- a/IIS/IIS-Components.psm1
+++ b/IIS/IIS-Components.psm1
@@ -274,8 +274,6 @@ function Uninstall-WebApplication {
         [string] $WebApplicationPath
     )
 
-    Remove-Item -Path $WebApplicationPath -Force -Recurse
-    
     $webApp = Get-WebApplication -Name $WebApplicationName -Site $WebSiteName
     $appPoolName = $webApp.ApplicationPool
     if ($null -ne $webApp) {
@@ -291,6 +289,8 @@ function Uninstall-WebApplication {
     else {
         Write-Warning "Unable to remove app pool '$appPoolName' because it is in use still."
     }
+
+    Get-ChildItem -Path $WebApplicationPath -Force -Recurse | Sort-Object -Property FullName -Descending | Remove-Item
 }
 
 function Get-PortNumber {

--- a/IIS/IIS-Components.psm1
+++ b/IIS/IIS-Components.psm1
@@ -291,6 +291,7 @@ function Uninstall-WebApplication {
     }
 
     Get-ChildItem -Path $WebApplicationPath -Force -Recurse | Sort-Object -Property FullName -Descending | Remove-Item
+    Remove-Item -Path $WebApplicationPath
 }
 
 function Get-PortNumber {


### PR DESCRIPTION
**Description**
As there is an [open issue](https://github.com/PowerShell/PowerShell/issues/8211) with the -Recurse parameter on Remove-Item causing it to fail intermittently, we decided to go with a work-around of using Get-ChildItem with Recurse and sorting to ensure that the children are passed before the parent directories/containers. This workaround is mentioned in the comments for this issue.