### PR TITLE
[AA-1424] Variable Dotnet Version

### DIFF
--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -184,10 +184,12 @@ function New-EdFiWebsite {
 }
 
 function Invoke-PrepareOperatingSystem {
+    param([hashtable]$Configuration)
+
     Invoke-Task -name ($MyInvocation.MyCommand.Name) -task {
         Import-Module -Force "$PSScriptRoot\..\Environment\Prerequisites.psm1"
 
-        Invoke-ThrowIfDotnetHostingBundleMissing
+        Invoke-ThrowIfDotnetHostingBundleMissing -VersionString $configuration.DotNetVersion
         
         Write-Info "Ensure all IIS modules are installed"
         Initialize-IISWithPrerequisites

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -321,7 +321,11 @@ function Install-EdFiApplicationIntoIIS {
 
         # Optionally disbable reporting of execution time.
         [switch]
-        $NoDuration
+        $NoDuration,
+
+        # Optionally reqiure specific dotnet version.
+        [string]
+        $DotNetVersion
     )
     $configuration = @{
         SourceLocation = $SourceLocation
@@ -333,6 +337,7 @@ function Install-EdFiApplicationIntoIIS {
         WebSitePort = $WebSitePort
         EnableAnonymousAuth = $EnableAnonymousAuth
         EnableWindowsAuth = $EnableWindowsAuth
+        DotNetVersion = $DotNetVersion
     }
 
     Write-InvocationInfo $MyInvocation

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -327,7 +327,7 @@ function Install-EdFiApplicationIntoIIS {
 
         # Optionally reqiure specific dotnet version.
         [string]
-        $DotNetVersion
+        $DotNetVersion = "6.0.0"
     )
     $configuration = @{
         SourceLocation = $SourceLocation

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -190,7 +190,7 @@ function Invoke-PrepareOperatingSystem {
         Import-Module -Force "$PSScriptRoot\..\Environment\Prerequisites.psm1"
 
         Invoke-ThrowIfDotnetHostingBundleMissing -VersionString $configuration.DotNetVersion
-        
+
         Write-Info "Ensure all IIS modules are installed"
         Initialize-IISWithPrerequisites
     }

--- a/Environment/Prerequisites.psm1
+++ b/Environment/Prerequisites.psm1
@@ -39,8 +39,8 @@ function Invoke-ThrowIfDotnetHostingBundleMissing {
                 $installedDotNetCoreVersion = [System.Version]::Parse($dotNetCoreVersion)
 
                 if($installedDotNetCoreVersion -ge $requiredVersion) {
-                    Write-Host "The host has the following .NET Core Hosting Bundle: $_ (MinimumVersion requirement: $requiredVersion)"  
-                    $requiredVersionInstalled = $True                      
+                    Write-Host "The host has the following .NET Core Hosting Bundle: $_ (MinimumVersion requirement: $requiredVersion)"
+                    $requiredVersionInstalled = $True
                 }
         }
     }
@@ -94,9 +94,9 @@ function Get-FileFromInternet {
     param (
         [string] [Parameter(Mandatory=$true)] $url
     )
-    
+
     New-Item -Force -ItemType Directory "downloads" | Out-Null
-    
+
     $fileName = $url.split('/')[-1]
     $output = "downloads\$fileName"
 
@@ -117,7 +117,7 @@ function Test-FileHash {
     )
 
     $calculated = (Get-FileHash $FilePath -Algorithm SHA512).Hash
- 
+
     if ($ExpectedHashValue -ne $calculated) {
         throw "Aborting install: cannot be sure of the integrity of the downloaded file " +
             "$FilePath. Please contact techsupport@ed-fi.org or create a " +
@@ -159,7 +159,7 @@ function Install-IISUrlRewriteModule {
 function Initialize-IISWithPrerequisites{
     param()
 
-    $restartNeeded = Enable-RequiredIisFeatures    
+    $restartNeeded = Enable-RequiredIisFeatures
 
     if (Get-Command "AI_GetMsiProperty" -ErrorAction SilentlyContinue) {
         $explanation = "Because the Advanced Installer package is running and responsible for MSI"
@@ -172,7 +172,7 @@ function Initialize-IISWithPrerequisites{
     Install-NuGetAndSqlServer
 
     Write-Host "Prerequisites verified" -ForegroundColor Green
-    
+
     return $restartNeeded
 }
 
@@ -204,7 +204,7 @@ function Install-DotNetCore {
 $functions = @(
     "Initialize-IISWithPrerequisites"
     "Test-MinimumPowershellInstalled"
-    "Install-DotNetCore"   
+    "Install-DotNetCore"
     "Invoke-ThrowIfDotnetHostingBundleMissing"
 )
 

--- a/Environment/Prerequisites.psm1
+++ b/Environment/Prerequisites.psm1
@@ -18,7 +18,9 @@ function Enable-IisFeature {
 }
 
 function Invoke-ThrowIfDotnetHostingBundleMissing {
-    $requiredVersion = [System.Version]::Parse("6.0.0")
+    param ([string]$VersionString = "6.0.0")
+
+    $requiredVersion = [System.Version]::Parse($VersionString)
 
     $updatesPath = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Updates\.NET"
     $items = Get-Item -ErrorAction SilentlyContinue -Path $updatesPath

--- a/Environment/Prerequisites.psm1
+++ b/Environment/Prerequisites.psm1
@@ -20,7 +20,12 @@ function Enable-IisFeature {
 function Invoke-ThrowIfDotnetHostingBundleMissing {
     param ([string]$VersionString = "6.0.0")
 
-    $requiredVersion = [System.Version]::Parse($VersionString)
+    try {
+        $requiredVersion = [System.Version]::Parse($VersionString)
+    }
+    catch [System.ArgumentException],[System.ArgumentOutOfRangeException],[System.FormatException],[System.OverflowException] {
+        throw "The input Version '$VersionString' could not be parsed and may be invalid. Version must be a valid semantic version number."
+    }
 
     $updatesPath = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Updates\.NET"
     $items = Get-Item -ErrorAction SilentlyContinue -Path $updatesPath

--- a/Environment/Prerequisites.psm1
+++ b/Environment/Prerequisites.psm1
@@ -42,8 +42,8 @@ function Invoke-ThrowIfDotnetHostingBundleMissing {
 
     if(-Not $requiredVersionInstalled)
     {
-        throw "The .NET 6 Hosting Bundle couldn't be found on the system, and is required for install. 
-        Please install $requiredVersion or greater. Can be downloaded from https://dotnet.microsoft.com/en-us/download/dotnet/6.0"
+        throw "The $VersionString .NET Hosting Bundle couldn't be found on the system, and is required for install.
+        Please install $requiredVersion or greater. Can be downloaded from https://dotnet.microsoft.com/en-us/download/dotnet"
     }
 }
 


### PR DESCRIPTION
Updates `Installer.AppCommon` to accept a `DotNetVersion` parameter as part of configuration when installing, instead of being hardcoded. This will allow **consumers** to specify what framework is needed, rather than coupling that requirement with versions of the Installer library.

- preserves `6.0.0` as a default to avoid breaking current consumers
- provides error handling for invalid format (this is helpful only for developers, as end-users will not be able to adjust version)
- also cleans up many dangling whitespaces