### PR TITLE
[AA-1480] - Update SQL login prompt for existing credentials

### DIFF
--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -547,7 +547,7 @@ function Add-SqlLogins {
             $postgresUsername = $postgresPromptInfo.Username
             $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
             if($IsCustomLogin){
-                $customUsernameConfirmation = Request-Information -DefaultValue 'y' -Prompt "Please enter 'y' to continue with ""$postgresUsername"" as PostgreSQL Login username. Or enter 'n' to enter a custom username"
+                $customUsernameConfirmation = Prompt-YN-Retry-Loop -Default 'y' -Prompt "Please enter 'y' to continue with ""$postgresUsername"" as PostgreSQL Login username. Or enter 'n' to enter a custom username"
                 if($customUsernameConfirmation -ieq 'n')
                 {
                     $postgresPromptInfo = Prompt-For-PostgreSQL-Username $postgresUsername
@@ -577,7 +577,7 @@ function Add-SqlLogins {
             }
             $sqlServerUsername = "IIS APPPOOL\$UserToCreate"
             if($IsCustomLogin){
-                $customUsernameConfirmation = Request-Information -DefaultValue 'y' -Prompt "Please enter 'y' to continue with ""$sqlServerUsername"" as SQL Login username. Or enter 'n' to enter a custom username"
+                $customUsernameConfirmation = Prompt-YN-Retry-Loop -DefaultValue 'y' -Prompt "Please enter 'y' to continue with ""$sqlServerUsername"" as SQL Login username. Or enter 'n' to enter a custom username"
                 if($customUsernameConfirmation -ieq 'n')
                 {
                     $sqlServerUsername = Prompt-For-SQLServer-Username $sqlServerUsername

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -550,21 +550,22 @@ function Add-SqlLogins {
                     $postgresUsername = $postgresPromptInfo.Username
                     $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
                 }
-            }
-
-            $sqlLoginCreated = Add-PostgreSqlLogin $databaseServer $postgresUsername $identityMapMessage
-            while(!$sqlLoginCreated) {
-                $retry = Prompt-YN-Retry-Loop 'Press y to re-enter the username and try again. Or press n to use the default username [y/N]?' 'n'
-                if ($retry -eq "y") {
-                    $postgresPromptInfo = Prompt-For-PostgreSQL-Username $postgresUsername
-                    $postgresUsername = $postgresPromptInfo.Username
-                    $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
-                } else {
-                    $postgresPromptInfo = Get-DefaultPostgresPromptInfo $UserToCreate
-                    $postgresUsername = $postgresPromptInfo.Username
-                    $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
-                }
                 $sqlLoginCreated = Add-PostgreSqlLogin $databaseServer $postgresUsername $identityMapMessage
+                while(!$sqlLoginCreated) {
+                    $retry = Prompt-YN-Retry-Loop 'Press y to re-enter the username and try again. Or press n to use the default username [y/N]?' 'n'
+                    if ($retry -eq "y") {
+                        $postgresPromptInfo = Prompt-For-PostgreSQL-Username $postgresUsername
+                        $postgresUsername = $postgresPromptInfo.Username
+                        $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
+                    } else {
+                        $postgresPromptInfo = Get-DefaultPostgresPromptInfo $UserToCreate
+                        $postgresUsername = $postgresPromptInfo.Username
+                        $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
+                    }
+                    $sqlLoginCreated = Add-PostgreSqlLogin $databaseServer $postgresUsername $identityMapMessage
+                }
+            } else {
+                Add-PostgreSqlLogin $databaseServer $postgresUsername $identityMapMessage
             }
         } else {
             If(-not(Get-Module -ListAvailable -Name SqlServer -ErrorAction silentlycontinue)){
@@ -577,17 +578,18 @@ function Add-SqlLogins {
                 {
                     $sqlServerUsername = Prompt-For-SQLServer-Username $sqlServerUsername
                 }
-            }
-
-            $sqlLoginCreated = Add-SqlServerLogin $databaseServer $sqlServerUsername
-            while(!$sqlLoginCreated) {
-                $retry = Prompt-YN-Retry-Loop 'Press y to re-enter the username and try again. Or press n to use the default username [y/N]?' 'n'
-                if ($retry -eq "y") {
-                    $sqlServerUsername = Prompt-For-SQLServer-Username $sqlServerUsername
-                } else {
-                    $sqlServerUsername = "IIS APPPOOL\$UserToCreate"
-                }
                 $sqlLoginCreated = Add-SqlServerLogin $databaseServer $sqlServerUsername
+                while(!$sqlLoginCreated) {
+                    $retry = Prompt-YN-Retry-Loop 'Press y to re-enter the username and try again. Or press n to use the default username [y/N]?' 'n'
+                    if ($retry -eq "y") {
+                        $sqlServerUsername = Prompt-For-SQLServer-Username $sqlServerUsername
+                    } else {
+                        $sqlServerUsername = "IIS APPPOOL\$UserToCreate"
+                    }
+                    $sqlLoginCreated = Add-SqlServerLogin $databaseServer $sqlServerUsername
+                }
+            } else {
+                Add-SqlServerLogin $databaseServer $sqlServerUsername
             }
         }
     } else {

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -434,6 +434,17 @@ function Test-DbLoginExistsWithBasicAuth {
     )
 }
 
+function Request-Information ($prompt, $defaultValue) {
+  $isInteractive = [Environment]::UserInteractive
+  if($isInteractive) {
+      $confirmation = Read-Host -Prompt $prompt
+  } else {
+      $confirmation = $defaultValue
+  }
+
+  return $confirmation
+}
+
 function Add-SqlLogins {
     [CmdletBinding()]
     Param(

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -547,7 +547,7 @@ function Add-SqlLogins {
             $postgresUsername = $postgresPromptInfo.Username
             $identityMapMessage = $postgresPromptInfo.IdentityMapMessage
             if($IsCustomLogin){
-                $customUsernameConfirmation = Prompt-YN-Retry-Loop -Default 'y' -Prompt "Please enter 'y' to continue with ""$postgresUsername"" as PostgreSQL Login username. Or enter 'n' to enter a custom username"
+                $customUsernameConfirmation = Prompt-YN-Retry-Loop -Default 'y' -Prompt "Continue with ""$postgresUsername"" for PostgreSQL Login? Press 'n' to customize [Y/n]"
                 if($customUsernameConfirmation -ieq 'n')
                 {
                     $postgresPromptInfo = Prompt-For-PostgreSQL-Username $postgresUsername
@@ -577,7 +577,7 @@ function Add-SqlLogins {
             }
             $sqlServerUsername = "IIS APPPOOL\$UserToCreate"
             if($IsCustomLogin){
-                $customUsernameConfirmation = Prompt-YN-Retry-Loop -DefaultValue 'y' -Prompt "Please enter 'y' to continue with ""$sqlServerUsername"" as SQL Login username. Or enter 'n' to enter a custom username"
+                $customUsernameConfirmation = Prompt-YN-Retry-Loop -DefaultValue 'y' -Prompt "Continue with ""$sqlServerUsername"" for SQL Login? Press 'n' to customize [Y/n]"
                 if($customUsernameConfirmation -ieq 'n')
                 {
                     $sqlServerUsername = Prompt-For-SQLServer-Username $sqlServerUsername

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -510,6 +510,16 @@ function Add-PostgreSqlLogin ($databaseServer, $postgresUsername, $identityMapMe
     return $sqlLoginCreated
 }
 
+function Get-DefaultPostgresPromptInfo ($userToCreate) {
+    $postgresUsername = $userToCreate.ToLower()
+    $identityMapMessage = "Created user ""$postgresUsername"" in PostgreSQL. Identity map for ""$userToCreate@IIS APPPOOL"" to ""$postgresUsername"" should be manually created."
+    $postgresPromptInfo = @{
+        Username = $postgresUsername
+        IdentityMapMessage = $identityMapMessage
+    }
+    return $postgresPromptInfo
+}
+
 function Add-SqlLogins {
     [CmdletBinding()]
     Param(

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -458,6 +458,21 @@ function Prompt-YN-Retry-Loop ($prompt, $default){
   return $result
 }
 
+function Prompt-For-SQLServer-Username ($sqlServerUsername) {
+  $sqlServerUsername = Request-Information -DefaultValue $sqlServerUsername -Prompt "Please enter a custom username for the SQL Login. You can use the username for an existing user login or a new user login will be created if it does not already exist. Please enter the username"
+  return $sqlServerUsername
+}
+
+function Prompt-For-PostgreSQL-Username ($postgresUsername) {
+  $postgresUsername = Request-Information -DefaultValue $postgresUsername -Prompt "Please enter a custom username for the PostgreSQL Login. You can use the username for an existing user login or a new user login will be created if it does not already exist. Please enter the username"
+  $identityMapMessage = "Created user ""$postgresUsername"" in PostgreSQL. Identity map for ""$postgresUsername"" should be manually created."
+  $postgresPromptInfo = @{
+      Username = $postgresUsername
+      IdentityMapMessage = $identityMapMessage
+  }
+  return $postgresPromptInfo
+}
+
 function Add-SqlLogins {
     [CmdletBinding()]
     Param(

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -446,6 +446,10 @@ function Request-Information ($prompt, $defaultValue) {
 }
 
 function Prompt-YN-Retry-Loop ($prompt, $default){
+  if(-not ([Environment]::UserInteractive)) {
+    return $default
+  }
+
   $result = Read-Host -Prompt $prompt
 
   if($result -eq '') {

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -445,6 +445,19 @@ function Request-Information ($prompt, $defaultValue) {
   return $confirmation
 }
 
+function Prompt-YN-Retry-Loop ($prompt, $default){
+  $result = Read-Host -Prompt $prompt
+
+  if($result -eq '') {
+    return $default
+  }
+  if($result -ne 'y' -and $result -ne 'n') {
+    return Prompt-YN-Retry-Loop $prompt $default
+  }
+
+  return $result
+}
+
 function Add-SqlLogins {
     [CmdletBinding()]
     Param(


### PR DESCRIPTION
**Description**
- Added Request-Information function to create prompts with default values.
- Added a retry prompt function to aid in retrying a task.
- Added prompt functions for SQLServer and Postgres to collect username (and other) information from the user.
- Added SQL login creation functions for SQLServer and Postgres and return if the task was successful or not.
- Added Get-DefaultPostgresPromptInfo to return the default Postgres login information and message to be used while adding the Sql login.
- Refactored Add-SqlLogins function to use a switch to setup custom logins and use the helper functions to accomplish the task of prompting the user to enter the custom username.