### PR TITLE
[ODS-6151] Require .NET 8, and add GitHub automation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
+
+[*.yml,*.yaml]
+indent_size = 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/**/*    @ed-fi-alliance-oss/ods-platform-automation-owners

--- a/.github/workflows/on-merge-or-tag.yml
+++ b/.github/workflows/on-merge-or-tag.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Merge to Main or Releasable Tag
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+
+env:
+  API_URL: https://api.github.com/repos/${{ github.repository }}
+  TOKEN: ${{ secrets.EDFI_BUILD_AGENT_PAT }}
+
+jobs:
+  create-pre-releases:
+    name: Create Pre-Releases
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          # MinVer needs to have more than just the current commit, so tell
+          # GitHub to get many more. Setting to 0 forces retrieval of _all_
+          # commits. Which might be excessive, but we don't know how many
+          # there will be between different major.minor releases.
+          fetch-depth: 0
+
+      - name: Set Version Numbers
+        id: versions
+        run: |
+          Import-Module ./github-builder.psm1
+          Get-VersionNumber
+
+      - name: Create AppCommon Pre-Release
+        run: |
+          $version = "${{ steps.versions.outputs.appcommon-semver }}"
+          $tag = $version -replace "v","pre-"
+
+          $body = @{
+            tag_name = "$tag"
+            target_commitish = "main"
+            name = $version
+            body = ""
+            draft = $false
+            prerelease = $true
+            generate_release_notes = $false
+          } | ConvertTo-Json
+
+          $headers = @{
+            Accept = "application/vnd.github+json"
+            Authorization = "Bearer ${{ env.TOKEN }}"
+          }
+
+          Invoke-RestMethod -Method POST -Uri ${{ env.API_URL }}/releases -Body $body -Headers $headers

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -82,8 +82,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+      - name: Get Artifact
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
         with:
           name: ${{ env.PACKAGE_NAME }}-NuGet
 
@@ -145,7 +145,7 @@ jobs:
       contents: write
     steps:
       - name: Download the SBOM
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@7f4fdb871876c23e455853d694197440c5a91506 #v1.5.0
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@07e64b653f10a80b6510f4568f685f8b7b9ea830 #v1.9.0
         with:
           name: "${{ env.PACKAGE_NAME }}-SBOM"
           path: ${{ env.MANIFEST_FILE }}
@@ -187,7 +187,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.5.0
+    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
     with:
       base64-subjects: ${{ needs.pack.outputs.hash-code }}
       provenance-name: AdminApi.intoto.jsonl

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -146,7 +146,7 @@ jobs:
       contents: write
     steps:
       - name: Download the SBOM
-        uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/actions/secure-download-artifact@ODS-6151
+        uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/actions/secure-download-artifact@main
         with:
           name: "${{ env.PACKAGE_NAME }}-SBOM"
           path: ${{ env.MANIFEST_FILE }}
@@ -188,7 +188,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@ODS-6151
+    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
     with:
       base64-subjects: ${{ needs.pack.outputs.hash-code }}
       provenance-name: EdFi.Installer.AppCommon.intoto.jsonl

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -31,6 +31,7 @@ jobs:
       appcommon-version: ${{ steps.versions.outputs.appcommon-v }}
 
     steps:
+      - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
@@ -76,7 +77,10 @@ jobs:
     outputs:
       sbom-hash-code: ${{ steps.sbom-hash-code.outputs.sbom-hash-code }}
     steps:
+      - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
 
       - name: Get Artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
@@ -199,7 +203,10 @@ jobs:
       run:
         shell: pwsh
     steps:
+      - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
 
       - name: Get Artifact
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -94,12 +94,12 @@ jobs:
           $version = "${{ needs.pack.outputs.appcommon-v }}"
 
           $url = "${{ env.SBOM_TOOL_URL }}"
-          $hash = "${{ env.SBOM_TOOL_HASH }}"
+          "${{ env.SBOM_TOOL_HASH }}" | Out-File hash-value
           $out = "$($env:RUNNER_TEMP)/sbom-tool-linux-x64"
           Invoke-RestMethod -Uri $url -OutFile $out
 
           pushd $($env:RUNNER_TEMP)
-          md5sum -c <<< $out
+          md5sum --check hash-value
           popd
 
           chmod +x $out

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Pre-Release
+on:
+  release:
+    types:
+      - prereleased
+
+env:
+  ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  ARTIFACTS_FEED_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  MANIFEST_FILE: "_manifest/spdx_2.2/manifest.spdx.json"
+  PACKAGE_NAME: "EdFi.Installer.AppCommon"
+  REF: ${{ github.ref_name }}
+  SBOM_TOOL_URL: ${{ vars.SBOM_TOOL_LINUX_X64_URL }}
+  SBOM_TOOL_HASH: ${{ vars.SBOM_TOOL_LINUX_X64_HASH }}
+
+jobs:
+  pack:
+    name: Build and Pack
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    outputs:
+      hash-code: ${{ steps.hash-code.outputs.hash-code }}
+      appcommon-version: ${{ steps.versions.outputs.appcommon-v }}
+
+    steps:
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Set Version Numbers
+        id: versions
+        shell: pwsh
+        run: |
+          Import-Module ./github-builder.psm1
+          Get-VersionNumber
+
+      - name: Create NuGet Package
+        shell: pwsh
+        run: |
+          $packageVersion = "${{ steps.versions.outputs.appcommon-semver }}"
+
+          Import-Module ./github-builder.psm1
+
+          Invoke-DotnetPack $packageVersion
+
+      - name: Generate hash for NuGet package
+        id: hash-code
+        shell: pwsh
+        run: |
+          "hash-code=$(sha256sum *.nupkg | base64 -w0)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Upload Packages as Artifacts
+        if: success()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: "${{ env.PACKAGE_NAME }}-NuGet"
+          path: ./*.nupkg
+          if-no-files-found: error
+          retention-days: 30
+
+  sbom-create:
+    name: Create SBOM
+    runs-on: ubuntu-latest
+    needs: pack
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      sbom-hash-code: ${{ steps.sbom-hash-code.outputs.sbom-hash-code }}
+    steps:
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        with:
+          name: ${{ env.PACKAGE_NAME }}-NuGet
+
+      - name: Generate Software Bill of Materials (SBOM) - API
+        shell: pwsh
+        run: |
+          $packageName = "${{ env.PACKAGE_NAME }}"
+          $version = "${{ needs.pack.outputs.appcommon-v }}"
+
+          $url = "${{ env.SBOM_TOOL_URL }}"
+          $hash = "${{ env.SBOM_TOOL_HASH }}"
+          $out = "$($env:RUNNER_TEMP)/sbom-tool-linux-x64"
+          Invoke-RestMethod -Uri $url -OutFile $out
+
+          pushd $($env:RUNNER_TEMP)
+          md5sum -c <<< $out
+          popd
+
+          chmod +x $out
+
+          (Resolve-Path ("./$($packageName).$($version).nupkg")).Path | Out-File -FilePath buildfilelist.txt
+          New-Item -Path manifest -Type Directory
+
+          &$out generate `
+              -b ./ `
+              -bl ./buildfilelist.txt `
+              -bc "./" `
+              -pn "$packageName" `
+              -pv $version `
+              -nsb https://ed-fi.org `
+              -m manifest `
+              -ps "Ed-Fi Alliance"
+
+      - name: Upload SBOM
+        if: success()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-SBOM
+          path: ./manifest
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Generate hash code for SBOM
+        id: sbom-hash-code
+        shell: bash
+        run: |
+          # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
+          sbom_hash=$(sha256sum ./manifest/${{ env.MANIFEST_FILE }} | awk '{split($0,a); print a[1]}')
+          echo "sbom-hash-code=$sbom_hash" >> $GITHUB_OUTPUT
+
+  sbom-attach:
+    name: Attach SBOM file
+    runs-on: ubuntu-latest
+    needs:
+      - sbom-create
+      - pack
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download the SBOM
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@7f4fdb871876c23e455853d694197440c5a91506 #v1.5.0
+        with:
+          name: "${{ env.PACKAGE_NAME }}-SBOM"
+          path: ${{ env.MANIFEST_FILE }}
+          sha256: "${{ needs.sbom-create.outputs.sbom-hash-code }}"
+
+      - name: Attach to release
+        shell: pwsh
+        run: |
+          $release = "${{ github.ref_name }}"
+          $repo = "${{ github.repository }}"
+          $token = "${{ secrets.GITHUB_TOKEN }}"
+          $file = "${{ env.MANIFEST_FILE }}"
+          $uploadName = "${{ env.PACKAGE_NAME }}-SBOM.zip"
+
+          $url = "https://api.github.com/repos/$repo/releases/tags/$release"
+
+          $gh_headers = @{
+              "Accept"        = "application/vnd.github+json"
+              "Authorization" = "Bearer $token"
+          }
+
+          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers
+          $releaseId = $response.id
+
+          $url = "https://uploads.github.com/repos/$repo/releases/$releaseId/assets"
+
+          Compress-Archive $file -DestinationPath $uploadName
+
+          $gh_headers["Content-Type"] = "application/octet"
+          Invoke-RestMethod -Method POST `
+              -Uri "$($url)?name=$($uploadName)" `
+              -Headers $gh_headers `
+              -InFile $uploadName
+
+  provenance-create:
+    name: Create Provenance
+    needs: pack
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.5.0
+    with:
+      base64-subjects: ${{ needs.pack.outputs.hash-code }}
+      provenance-name: AdminApi.intoto.jsonl
+      upload-assets: true
+      # TODO: remove this after this issue is resolved: https://github.com/slsa-framework/slsa-github-generator/issues/876
+      compile-generator: true
+
+  publish-package:
+    name: Publish NuGet Package
+    needs: pack
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Artifact
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-NuGet
+
+      - name: Install-credential-handler
+        run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+
+      - name: Push Package to Azure Artifacts
+        run: |
+          Import-Module ./github-builder.psm1
+          Invoke-NuGetPush -NuGetFeed ${{ env.ARTIFACTS_FEED_URL }} -NuGetApiKey ${{ env.ARTIFACTS_API_KEY }}

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: ${{ env.PACKAGE_NAME }}-SBOM
-          path: manifest.spdx.*
+          path: ${{ env.MANIFEST_FILE }}
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           name: ${{ env.PACKAGE_NAME }}-NuGet
 
-      - name: Generate Software Bill of Materials (SBOM) - API
+      - name: Generate Software Bill of Materials (SBOM)
         shell: pwsh
         run: |
           $packageName = "${{ env.PACKAGE_NAME }}"

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: "${{ env.PACKAGE_NAME }}-NuGet"
-          path: ./*.nupkg
+          path: ${{ github.workspace }}/*.nupkg
           if-no-files-found: error
           retention-days: 30
 
@@ -190,7 +190,7 @@ jobs:
     uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
     with:
       base64-subjects: ${{ needs.pack.outputs.hash-code }}
-      provenance-name: AdminApi.intoto.jsonl
+      provenance-name: EdFi.Installer.AppCommon.intoto.jsonl
       upload-assets: true
       # TODO: remove this after this issue is resolved: https://github.com/slsa-framework/slsa-github-generator/issues/876
       compile-generator: true

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -13,7 +13,7 @@ env:
   ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   ARTIFACTS_FEED_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
-  MANIFEST_FILE: "_manifest/spdx_2.2/manifest.spdx.json"
+  MANIFEST_FILE: "manifest.spdx.json"
   PACKAGE_NAME: "EdFi.Installer.AppCommon"
   REF: ${{ github.ref_name }}
   SBOM_TOOL_URL: ${{ vars.SBOM_TOOL_LINUX_X64_URL }}
@@ -28,7 +28,7 @@ jobs:
         shell: pwsh
     outputs:
       hash-code: ${{ steps.hash-code.outputs.hash-code }}
-      appcommon-version: ${{ steps.versions.outputs.appcommon-v }}
+      appcommon-v: ${{ steps.versions.outputs.appcommon-v }}
 
     steps:
       - name: Checkout repository
@@ -105,7 +105,6 @@ jobs:
           chmod +x $out
 
           (Resolve-Path ("./$($packageName).$($version).nupkg")).Path | Out-File -FilePath buildfilelist.txt
-          New-Item -Path manifest -Type Directory
 
           &$out generate `
               -b ./ `
@@ -114,15 +113,17 @@ jobs:
               -pn "$packageName" `
               -pv $version `
               -nsb https://ed-fi.org `
-              -m manifest `
+              -m ./ `
               -ps "Ed-Fi Alliance"
+
+          cp _manifest/spdx_2.2/manifest.spdx.* .
 
       - name: Upload SBOM
         if: success()
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: ${{ env.PACKAGE_NAME }}-SBOM
-          path: ./manifest
+          path: manifest.spdx.*
           if-no-files-found: error
           retention-days: 30
 
@@ -131,7 +132,7 @@ jobs:
         shell: bash
         run: |
           # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
-          sbom_hash=$(sha256sum ./manifest/${{ env.MANIFEST_FILE }} | awk '{split($0,a); print a[1]}')
+          sbom_hash=$(sha256sum ./${{ env.MANIFEST_FILE }} | awk '{split($0,a); print a[1]}')
           echo "sbom-hash-code=$sbom_hash" >> $GITHUB_OUTPUT
 
   sbom-attach:
@@ -145,7 +146,7 @@ jobs:
       contents: write
     steps:
       - name: Download the SBOM
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@07e64b653f10a80b6510f4568f685f8b7b9ea830 #v1.9.0
+        uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/actions/secure-download-artifact@ODS-6151
         with:
           name: "${{ env.PACKAGE_NAME }}-SBOM"
           path: ${{ env.MANIFEST_FILE }}
@@ -187,7 +188,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@main
+    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@ODS-6151
     with:
       base64-subjects: ${{ needs.pack.outputs.hash-code }}
       provenance-name: EdFi.Installer.AppCommon.intoto.jsonl

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -33,11 +33,16 @@ jobs:
 
       - name: Checkout the Repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0w
 
       - name: Build the package
         shell: pwsh
         run: |
           Import-Module ./Utility/create-package.psm1
           Invoke-DotnetPack "$env:PackageVersion"
+
+    - name: Upload Package as Artifact
+      if: success()
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      with:
+        name: NugetPackages
+        path: ${{ github.workspace }}/*.nupkg

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -38,7 +38,7 @@ jobs:
         shell: pwsh
         run: |
           Import-Module ./Utility/create-package.psm1
-          Invoke-DotnetPack "$env:PackageVersion"
+          Invoke-DotnetPack "$($env:PackageVersion)-${{ github.run_number }}"
 
       - name: Upload Package as Artifact
         if: success()

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PackageVersion: vars.APP_COMMON_PACKAGE_VERSION
+  PackageVersion: ${{ vars.APP_COMMON_PACKAGE_VERSION }}
 
 jobs:
   scan-actions:

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -38,4 +38,6 @@ jobs:
 
       - name: Build the package
         shell: pwsh
-        run: Invoke-DotnetPack "$env:PackageVersion"
+        run: |
+          Import-Module ./Utility/create-package.psm1
+          Invoke-DotnetPack "$env:PackageVersion"

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build the package
         shell: pwsh
-        runs: Invoke-DotnetPack "$env:PackageVersion"
+        run: Invoke-DotnetPack "$env:PackageVersion"

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Set Version Numbers
         id: versions
+        shell: pwsh
         run: |
           Import-Module ./github-builder.psm1
           Get-VersionNumber

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Pull Request
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PackageVersion: vars.APP_COMMON_PACKAGE_VERSION
+
+jobs:
+  scan-actions:
+    name: Scan Actions
+    uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/repository-scanner.yml@main
+
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout the Repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0w
+
+      - name: Build the package
+        shell: pwsh
+        runs: Invoke-DotnetPack "$env:PackageVersion"

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -33,11 +33,20 @@ jobs:
 
       - name: Checkout the Repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Set Version Numbers
+        id: versions
+        run: |
+          Import-Module ./github-builder.psm1
+          Get-VersionNumber
 
       - name: Build the package
         shell: pwsh
         run: |
-          Import-Module ./Utility/create-package.psm1
+          Import-Module ./github-builder.psm1
+
           Invoke-DotnetPack "$($env:PackageVersion)-${{ github.run_number }}"
 
       - name: Upload Package as Artifact

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -46,9 +46,11 @@ jobs:
       - name: Build the package
         shell: pwsh
         run: |
+          $packageVersion = "${{ steps.versions.outputs.appcommon-semver }}"
+
           Import-Module ./github-builder.psm1
 
-          Invoke-DotnetPack "$($env:PackageVersion)-${{ github.run_number }}"
+          Invoke-DotnetPack $packageVersion
 
       - name: Upload Package as Artifact
         if: success()

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -40,9 +40,9 @@ jobs:
           Import-Module ./Utility/create-package.psm1
           Invoke-DotnetPack "$env:PackageVersion"
 
-    - name: Upload Package as Artifact
-      if: success()
-      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
-      with:
-        name: NugetPackages
-        path: ${{ github.workspace }}/*.nupkg
+      - name: Upload Package as Artifact
+        if: success()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+            name: NugetPackages
+            path: ${{ github.workspace }}/*.nupkg

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Release
+on:
+  release:
+    types:
+      - released
+
+env:
+  ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  ARTIFACTS_FEED_URL: ${{ vars.AZURE_ARTIFACTS_FEED_URL }}
+  ARTIFACTS_PACKAGES_URL: ${{ vars.ARTIFACTS_PACKAGES_URL }}
+  ARTIFACTS_USERNAME: ${{ secrets.AZURE_ARTIFACTS_USER_NAME }}
+
+jobs:
+  delete-pre-releases:
+    name: Delete Unnecessary Pre-Releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Delete other pre-releases and their tags
+        shell: pwsh
+        run: |
+          $release = "${{ github.ref_name }}"
+          $repo = "${{ github.repository }}"
+          $token = "${{ secrets.GITHUB_TOKEN }}"
+
+          $page = 1
+          $release_list = @()
+
+          Do {
+
+            $url = "https://api.github.com/repos/$repo/releases?per_page=100&page=$page"
+            $gh_headers = @{
+                "Accept"        = "application/vnd.github+json"
+                "Authorization" = "Bearer $token"
+            }
+
+            $release_list = Invoke-RestMethod $url -Headers $gh_headers
+
+            $release_list | ForEach-Object {
+                if ($_.tag_name -like "Pre-Release-*" -and $_.prerelease) {
+                    "Deleting pre-release $($_.tag_name)" | Write-Output
+                    Invoke-RestMethod -Method Delete -Uri $_.url -Headers $gh_headers
+                }
+            }
+
+            $page += 1
+          } While ($release_list.count -gt 0)
+
+  promote-Azure-artifact:
+    name: Promote Azure Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Promote Package
+        shell: pwsh
+        run: |
+          $arguments = @{
+            FeedsURL    = "${{ env.ARTIFACTS_FEED_URL }}"
+            PackagesURL = "${{ env.ARTIFACTS_PACKAGES_URL }}"
+            Username    = "${{ env.ARTIFACTS_USERNAME }}"
+            View        = "release"
+            ReleaseRef  = "${{ github.ref_name }}"
+            Password    = (ConvertTo-SecureString -String "${{ env.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
+          }
+
+          Import-Module ./github-build.psm1
+          Invoke-Promote @arguments

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ credentials-*.xml
 #lib directory
 libs/
 libs.codegen/
+
+manifest/**/*
+buildfilelist.txt
+sbom-tool-*

--- a/Application/Install.psm1
+++ b/Application/Install.psm1
@@ -327,7 +327,7 @@ function Install-EdFiApplicationIntoIIS {
 
         # Optionally reqiure specific dotnet version.
         [string]
-        $DotNetVersion = "6.0.0"
+        $DotNetVersion = "8.0.0"
     )
     $configuration = @{
         SourceLocation = $SourceLocation

--- a/EdFi.Installer.AppCommon.csproj
+++ b/EdFi.Installer.AppCommon.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>EdFi.Installer.AppCommon</RootNamespace>
+        <NoWarn>NU5110,NU5111</NoWarn>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <VersionPrefix>1.0.0</VersionPrefix>
+        <NuspecFile>EdFi.Installer.AppCommon.nuspec</NuspecFile>
+        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="docs\" />
+    </ItemGroup>
+
+</Project>

--- a/EdFi.Installer.AppCommon.nuspec
+++ b/EdFi.Installer.AppCommon.nuspec
@@ -9,7 +9,7 @@
     <copyright>Copyright © 2024, Ed-Fi Alliance, LLC and contributors.</copyright>
     <summary>Helper modules and functions for configuring and installing Ed-Fi applications</summary>
     <description>Helper modules and functions for configuring and installing Ed-Fi applications</description>
-    <readme>docs\readme.md</readme>
+    <readme>docs\README.md</readme>
   </metadata>
   <files>
     <file src="**/*.psm1" target="" />

--- a/EdFi.Installer.AppCommon.nuspec
+++ b/EdFi.Installer.AppCommon.nuspec
@@ -6,12 +6,15 @@
     <title>Application installer modules</title>
     <authors>Ed-Fi Alliance</authors>
     <projectUrl>https://github.com/Ed-Fi-Alliance/Ed-Fi-ODS-Deploy</projectUrl>
-    <copyright>Copyright © 2020, Ed-Fi Alliance, LLC and contributors.</copyright>
+    <copyright>Copyright © 2024, Ed-Fi Alliance, LLC and contributors.</copyright>
     <summary>Helper modules and functions for configuring and installing Ed-Fi applications</summary>
     <description>Helper modules and functions for configuring and installing Ed-Fi applications</description>
+    <readme>docs\readme.md</readme>
   </metadata>
   <files>
     <file src="**/*.psm1" target="" />
     <file src="**/*.ps1" target="" exclude="build-package.ps1" />
+    <file src="LICENSE" target="docs\" />
+    <file src="README.md" target="docs\" />
   </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # EdFi.Installer.AppCommon
-PowerShell library containing scripts used by application installers packages
+
+PowerShell library containing scripts used by application installers packages.
 
 ## Legal Information
 
-Copyright (c) 2021 Ed-Fi Alliance, LLC and contributors.
+Copyright (c) 2024 Ed-Fi Alliance, LLC and contributors.
 
 Licensed under the [Apache License, Version 2.0](LICENSE) (the "License").
 

--- a/Utility/create-package.psm1
+++ b/Utility/create-package.psm1
@@ -200,7 +200,7 @@ function Invoke-DotnetPack {
         $Version
     )
 
-    dotnet pack --no-build -p:PackageVersion=$Version
+    dotnet pack -p:PackageVersion=$Version
 }
 
 Export-ModuleMember -Function Invoke-CreatePackage, Invoke-DotnetPack

--- a/Utility/create-package.psm1
+++ b/Utility/create-package.psm1
@@ -192,15 +192,5 @@ function Publish-PrereleasePackage {
     & $NuGet @parameters
 }
 
-function Invoke-DotnetPack {
-    [CmdletBinding()]
-    param (
-        [string]
-        [Parameter(Mandatory = $true)]
-        $Version
-    )
 
-    dotnet pack -p:PackageVersion=$Version -o ./
-}
-
-Export-ModuleMember -Function Invoke-CreatePackage, Invoke-DotnetPack
+Export-ModuleMember -Function Invoke-CreatePackage

--- a/Utility/create-package.psm1
+++ b/Utility/create-package.psm1
@@ -200,7 +200,7 @@ function Invoke-DotnetPack {
         $Version
     )
 
-    dotnet pack -p:PackageVersion=$Version
+    dotnet pack -p:PackageVersion=$Version -o ./
 }
 
 Export-ModuleMember -Function Invoke-CreatePackage, Invoke-DotnetPack

--- a/Utility/create-package.psm1
+++ b/Utility/create-package.psm1
@@ -192,4 +192,15 @@ function Publish-PrereleasePackage {
     & $NuGet @parameters
 }
 
-Export-ModuleMember -Function Invoke-CreatePackage
+function Invoke-DotnetPack {
+    [CmdletBinding()]
+    param (
+        [string]
+        [Parameter(Mandatory = $true)]
+        $Version
+    )
+
+    dotnet pack --no-build -p:PackageVersion=$Version
+}
+
+Export-ModuleMember -Function Invoke-CreatePackage, Invoke-DotnetPack

--- a/github-builder.psm1
+++ b/github-builder.psm1
@@ -17,7 +17,7 @@ function Get-VersionNumber {
 
     $version = $(&minver -t $prefix)
 
-    "appcommon-v$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    "appcommon-v=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
     "appcommon-semver=$($version -Replace $prefix)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 }
 

--- a/github-builder.psm1
+++ b/github-builder.psm1
@@ -49,4 +49,4 @@ function Invoke-NuGetPush {
     }
 }
 
-Export-ModuleMember -Function Get-VersionNumber, Invoke-DotnetPack
+Export-ModuleMember -Function Get-VersionNumber, Invoke-DotnetPack, Invoke-NuGetPush

--- a/github-builder.psm1
+++ b/github-builder.psm1
@@ -15,10 +15,10 @@ function Get-VersionNumber {
     # Install the MinVer CLI tool
     &dotnet tool install --global minver-cli
 
-    $version = $(minver -t $prefix)
+    $version = $(&minver -t $prefix)
 
-    "appcommon-v$version" >> $env:GITHUB_OUTPUT
-    "appcommon-semver=$($version -Replace $prefix)" >> $env:GITHUB_OUTPUT
+    "appcommon-v$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    "appcommon-semver=$($version -Replace $prefix)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 }
 
 function Invoke-DotnetPack {
@@ -29,7 +29,7 @@ function Invoke-DotnetPack {
         $Version
     )
 
-    dotnet pack -p:PackageVersion=$Version -o ./
+    &dotnet pack -p:PackageVersion=$Version -o ./
 }
 
 function Invoke-NuGetPush {

--- a/github-builder.psm1
+++ b/github-builder.psm1
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+
+#requires -version 7
+
+$ErrorActionPreference = "Stop"
+
+function Get-VersionNumber {
+
+    $prefix = "v"
+
+    # Install the MinVer CLI tool
+    &dotnet tool install --global minver-cli
+
+    $version = $(minver -t $prefix)
+
+    "appcommon-v$version" >> $env:GITHUB_OUTPUT
+    "appcommon-semver=$($version -Replace $prefix)" >> $env:GITHUB_OUTPUT
+}
+
+function Invoke-DotnetPack {
+    [CmdletBinding()]
+    param (
+        [string]
+        [Parameter(Mandatory = $true)]
+        $Version
+    )
+
+    dotnet pack -p:PackageVersion=$Version -o ./
+}
+
+function Invoke-NuGetPush {
+    [CmdletBinding()]
+    param (
+        [string]
+        [Parameter(Mandatory = $true)]
+        $NuGetFeed,
+
+        [string]
+        [Parameter(Mandatory = $true)]
+        $NuGetApiKey
+    )
+
+    (Get-ChildItem -Path $_ -Name -Include *.nupkg) | ForEach-Object {
+        &dotnet nuget push $_ --api-key $NuGetApiKey --source $NuGetFeed
+    }
+}
+
+Export-ModuleMember -Function Get-VersionNumber, Invoke-DotnetPack


### PR DESCRIPTION
Evidence of testing in my fork:

* [pull request](https://github.com/stephenfuqua/EdFi.Installer.AppCommon/actions/runs/8013994894), which fails only because of the temporary use of the @ODS-6151  branch for the SLSA actions.
* [merge to main](https://github.com/stephenfuqua/EdFi.Installer.AppCommon/actions/workflows/on-merge-or-tag.yml)
* [pre-release](https://github.com/stephenfuqua/EdFi.Installer.AppCommon/actions/runs/8013998184), which fails because I did not setup Azure artifacts credentials in my fork, so that I would not publish a real library.
* [release](https://github.com/stephenfuqua/EdFi.Installer.AppCommon/actions/runs/8014021937), which likewise fails due to the lack of an Azure Artifacts token.

Requires merge of two more PR's first:

* https://github.com/Ed-Fi-Alliance-OSS/slsa-github-generator/pull/1
* https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Actions/pull/70