### PR TITLE
[ODS-4936] Installer support and Integrated Security 

### DIFF
--- a/Application/Configuration.psm1
+++ b/Application/Configuration.psm1
@@ -159,14 +159,12 @@ function Assert-DatabaseConnectionInfo {
     if (-not $DbConnectionInfo.ContainsKey("Server")) {
         throw $template + "Server"
     }
-    if (-not $DbConnectionInfo.ContainsKey("UseIntegratedSecurity")) {
+    if (-not $DbConnectionInfo.ContainsKey("UseIntegratedSecurity") -or (-not $DbConnectionInfo.UseIntegratedSecurity)) {
         if (-not $DbConnectionInfo.ContainsKey("Username")) {
             throw $template + "Username"
         }
-        if ("sqlserver" -ieq $DbConnectionInfo.Engine) {
-            if (-not $DbConnectionInfo.ContainsKey("Password")) {
-                throw $template + "Password"
-            }
+        if (-not $DbConnectionInfo.ContainsKey("Password")) {
+            throw $template + "Password"
         }
     }
 


### PR DESCRIPTION
Summary of Changes:
- Update database connection information validation logic to require username and password in all cases when integrated security is not selected
- Remove alternate username prompts
- Change to using the credentials in the database connection information when creating a new sql login
- Add support for creating new database logins that do not use integrated security